### PR TITLE
fix: replace insecure git:// URL with https:// for python-libnmap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask
 flask-pymongo
 
 # new dependencies
-git+git://github.com/savon-noir/python-libnmap
-git+git://github.com/pidgeyl/specter
+git+https://github.com/savon-noir/python-libnmap
+git+https://github.com/pidgeyl/specter
 
 weasyprint


### PR DESCRIPTION
GitHub no longer supports the git:// protocol due to security concerns. Using https:// ensures compatibility and avoids connection timeouts, especially in restricted or firewalled environments.